### PR TITLE
Allow the connection URL to be missing the mongodb:// protocol

### DIFF
--- a/machines/create-manager.js
+++ b/machines/create-manager.js
@@ -190,8 +190,16 @@ module.exports = {
     // (call `malformed` if invalid).
     //
     // Remember: connection string takes priority over `meta` in the event of a conflict.
+    var connectionString = inputs.connectionString;
     try {
-      var parsedConnectionStr = url.parse(inputs.connectionString);
+      // We don't actually care about the protocol, the MongoDB drivr does,
+      // plus `url.parse()` returns funky results if the argument doesn't have one.
+      // So we'll add one if necessary.
+      // See https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Syntax
+      if (!connectionString.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//)) {
+        connectionString = 'mongodb://' + connectionString;
+      }
+      var parsedConnectionStr = url.parse(connectionString);
 
       // Validate that a protocol was found before other pieces
       // (otherwise other parsed info will be very weird and wrong)
@@ -217,7 +225,7 @@ module.exports = {
       });
     }
 
-    MongoClient.connect(inputs.connectionString, _clientConfig, function connectCb(err, db) {
+    MongoClient.connect(connectionString, _clientConfig, function connectCb(err, db) {
       if (err) {
         return exits.error({
           error: err,

--- a/test/connectable/create-manager.js
+++ b/test/connectable/create-manager.js
@@ -3,17 +3,29 @@ var Pack = require('../../');
 
 describe('Connectable ::', function() {
   describe('Create Manager', function() {
-    it('should validate the connection string has a protocol', function(done) {
+    it('should work without a protocol in the connection string', function(done) {
       Pack.createManager({
         connectionString: 'localhost:27017/mppg'
       })
       .exec(function(err) {
-        assert(err);
-        assert.equal(err.exit, 'malformed');
-
+        if (err) {
+          return done(err);
+        }
         return done();
       });
     });
+
+    it('should not work with an invalid protocol in the connection string', function(done) {
+      Pack.createManager({
+        connectionString: 'foobar://localhost:27017/mppg'
+      })
+      .exec(function(err) {
+        assert(err);
+        assert.equal(err.exit, 'malformed');
+        return done();
+      });
+    });
+
 
     it('should successfully return a Mongo Server instance', function(done) {
       // Needed to dynamically get the host using the docker container


### PR DESCRIPTION
The MongoDB driver actual does require the protocol, but we can add it on if it's missing.